### PR TITLE
Add database schema for clean installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Linkify.Bio website
+
+Small PHP app for creating a simple bio page with social auth and editable links.
+
+## Database setup
+
+This project expects a MySQL-compatible database named `linkify.bio` by default.
+
+1. Create the database and tables:
+
+   ```sql
+   SOURCE database/schema.sql;
+   ```
+
+   Or from the shell:
+
+   ```bash
+   mysql -u root -p < database/schema.sql
+   ```
+
+2. Update `components/configuration.php` with your local database credentials if needed.
+
+## Schema notes
+
+The checked-in schema covers the tables the app currently uses:
+
+- `users`
+  - stores profile data plus Instagram and Twitter auth fields
+- `links`
+  - stores each user link, enabled state, impressions, and clicks
+
+The SQL was inferred from the current PHP queries so new installs do not have to reverse engineer the table structure from the source.

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,40 @@
+-- Linkify.Bio database bootstrap
+-- Matches the current PHP code paths in this repository.
+
+CREATE DATABASE IF NOT EXISTS `linkify.bio`
+  CHARACTER SET utf8mb4
+  COLLATE utf8mb4_unicode_ci;
+
+USE `linkify.bio`;
+
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `username` VARCHAR(64) NOT NULL,
+  `full_name` VARCHAR(255) DEFAULT NULL,
+  `image_url` VARCHAR(2048) DEFAULT NULL,
+  `bio` TEXT,
+  `instagram_id` VARCHAR(64) DEFAULT NULL,
+  `instagram_access_token` VARCHAR(255) DEFAULT NULL,
+  `twitter_id` VARCHAR(64) DEFAULT NULL,
+  `twitter_oauth_token` VARCHAR(255) DEFAULT NULL,
+  `twitter_oauth_token_secret` VARCHAR(255) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_username_unique` (`username`),
+  KEY `users_instagram_id_index` (`instagram_id`),
+  KEY `users_twitter_id_index` (`twitter_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `links` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` INT UNSIGNED NOT NULL,
+  `url` VARCHAR(2048) NOT NULL,
+  `name` VARCHAR(255) NOT NULL,
+  `is_enabled` TINYINT(1) NOT NULL DEFAULT 1,
+  `impressions` INT UNSIGNED NOT NULL DEFAULT 0,
+  `clicks` INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `links_user_id_index` (`user_id`),
+  CONSTRAINT `links_user_id_foreign`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- add a checked-in MySQL schema for the tables the app currently uses
- document how to load the schema for a fresh install
- note that the schema was inferred from the existing PHP queries

## Testing
- unable to run PHP lint/build checks in this environment because `php` is not installed

Closes #1